### PR TITLE
feat: parse SQL statement types with node-sql-parser instead of rely on the first token.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.8.0",
     "dotenv": "^16.4.7",
-    "mysql2": "^3.14.0"
+    "mysql2": "^3.14.0",
+    "node-sql-parser": "^5.3.8"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
server used to rely on the first token of the SQL query (e.g., “SELECT”, “UPDATE”) to decide whether it was a read or write query. This was prone to errors when queries started with non-standard tokens or subqueries. By using node-sql-parser, we now inspect the actual AST and accurately detect statement types such as SELECT, INSERT, UPDATE, DELETE, etc. This approach is more reliable and reduces false positives.