### PR TITLE
Multi-DB Support and Schema-Specific Permissions

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,12 +1,45 @@
+# Basic MySQL connection settings
 MYSQL_HOST=127.0.0.1
 MYSQL_PORT=3306
 MYSQL_USER=root
-MYSQL_PASS=password
-MYSQL_DB=your_database_name
-MYSQL_SSL=false
-MYSQL_SSL_REJECT_UNAUTHORIZED=false
+MYSQL_PASS=your_password
+MYSQL_DB=
 
-# Write operation settings (default to false for security)
+# Leave MYSQL_DB empty for multi-DB mode
+# Set MYSQL_DB to a specific database name for single-DB mode
+
+# Global write operation permissions (default to false for safety)
 ALLOW_INSERT_OPERATION=false
 ALLOW_UPDATE_OPERATION=false
-ALLOW_DELETE_OPERATION=false 
+ALLOW_DELETE_OPERATION=false
+ALLOW_DDL_OPERATION=false
+
+# Schema-specific permissions
+# Format: "schema1:true,schema2:false"
+SCHEMA_INSERT_PERMISSIONS=test_db:true,staging_db:false
+SCHEMA_UPDATE_PERMISSIONS=test_db:true,staging_db:false
+SCHEMA_DELETE_PERMISSIONS=test_db:false,staging_db:false
+SCHEMA_DDL_PERMISSIONS=test_db:true,staging_db:false
+
+# Multi-DB mode settings
+# Set to true ONLY if you want to allow write operations in multi-DB mode without
+# schema-specific permissions (not recommended)
+MULTI_DB_WRITE_MODE=false
+
+# SSL configuration
+MYSQL_SSL=false
+MYSQL_SSL_REJECT_UNAUTHORIZED=true
+
+# Performance settings
+MYSQL_POOL_SIZE=10
+MYSQL_QUERY_TIMEOUT=30000
+MYSQL_CACHE_TTL=60000
+
+# Security settings
+MYSQL_RATE_LIMIT=100
+MYSQL_MAX_QUERY_COMPLEXITY=1000
+
+# Monitoring settings
+MYSQL_ENABLE_LOGGING=false
+MYSQL_LOG_LEVEL=info
+MYSQL_METRICS_ENABLED=false

--- a/README-MULTI-DB.md
+++ b/README-MULTI-DB.md
@@ -1,0 +1,155 @@
+# Multi-DB Mode and Schema-Specific Permissions
+
+This document describes the new multi-database mode and schema-specific permissions features added to the MCP-Server-MySQL.
+
+## Multi-DB Mode
+
+MCP-Server-MySQL now supports working with multiple databases simultaneously when no specific database is set in the configuration.
+
+### How to Enable Multi-DB Mode
+
+To enable multi-DB mode, simply leave the `MYSQL_DB` environment variable empty:
+
+```json
+{
+  "mcpServers": {
+    "mcp_server_mysql": {
+      "env": {
+        "MYSQL_HOST": "127.0.0.1",
+        "MYSQL_PORT": "3306",
+        "MYSQL_USER": "root",
+        "MYSQL_PASS": "your_password",
+        "MYSQL_DB": "", // Empty to enable multi-DB mode
+        ...
+      }
+    }
+  }
+}
+```
+
+### Features in Multi-DB Mode
+
+1. **List All Databases**: In multi-DB mode, the server will list resources from all available databases when the LLM requests database schemas.
+
+2. **Query Any Database**: You can execute queries against any database to which the MySQL user has access.
+
+3. **Schema Qualification Required**: When working in multi-DB mode, you should use fully qualified table names with schema/database prefixes:
+   ```sql
+   -- Use fully qualified table names
+   SELECT * FROM database_name.table_name;
+   
+   -- Or use USE statements to switch between databases
+   USE database_name;
+   SELECT * FROM table_name;
+   ```
+
+4. **Automatic Read-Only Mode**: For safety, multi-DB mode enforces read-only operations by default. This can be customized using schema-specific permissions (see below).
+
+5. **Database Exploration**: You can explore databases using commands like:
+   ```sql
+   -- List all databases
+   SHOW DATABASES;
+   
+   -- List tables in a specific database
+   SHOW TABLES FROM database_name;
+   
+   -- Describe a table's structure
+   DESCRIBE database_name.table_name;
+   ```
+
+## Schema-Specific Permissions
+
+This new feature allows fine-grained control over which operations are allowed on specific database schemas.
+
+### Available Permission Types
+
+1. **INSERT Permissions**: Control which schemas can have new records inserted.
+2. **UPDATE Permissions**: Control which schemas can have records updated.
+3. **DELETE Permissions**: Control which schemas can have records deleted.
+4. **DDL Permissions**: Control which schemas can have their structure modified (CREATE, ALTER, DROP, TRUNCATE).
+
+### How to Configure Schema-Specific Permissions
+
+Set the following environment variables with a comma-separated list of schema:permission pairs:
+
+```
+SCHEMA_INSERT_PERMISSIONS=production:false,development:true,test:true
+SCHEMA_UPDATE_PERMISSIONS=production:false,development:true,test:true
+SCHEMA_DELETE_PERMISSIONS=production:false,development:false,test:true
+SCHEMA_DDL_PERMISSIONS=production:false,development:false,test:true
+```
+
+This configuration:
+- Allows INSERT and UPDATE on development and test databases, but not production
+- Allows DELETE and DDL operations only on the test database
+- Blocks all write operations on the production database
+
+### Example Configuration
+
+Here's a complete example configuration with schema-specific permissions:
+
+```json
+{
+  "mcpServers": {
+    "mcp_server_mysql": {
+      "command": "npx",
+      "args": ["-y", "@benborla29/mcp-server-mysql"],
+      "env": {
+        "MYSQL_HOST": "127.0.0.1",
+        "MYSQL_PORT": "3306",
+        "MYSQL_USER": "root",
+        "MYSQL_PASS": "your_password",
+        "MYSQL_DB": "", // Empty for multi-DB mode
+        
+        // Global defaults (apply when no schema-specific permission is set)
+        "ALLOW_INSERT_OPERATION": "false",
+        "ALLOW_UPDATE_OPERATION": "false",
+        "ALLOW_DELETE_OPERATION": "false",
+        "ALLOW_DDL_OPERATION": "false",
+        
+        // Schema-specific permissions
+        "SCHEMA_INSERT_PERMISSIONS": "dev_db:true,test_db:true,prod_db:false",
+        "SCHEMA_UPDATE_PERMISSIONS": "dev_db:true,test_db:true,prod_db:false",
+        "SCHEMA_DELETE_PERMISSIONS": "dev_db:false,test_db:true,prod_db:false",
+        "SCHEMA_DDL_PERMISSIONS": "dev_db:false,test_db:true,prod_db:false"
+      }
+    }
+  }
+}
+```
+
+### Permission Resolution Logic
+
+1. If a schema-specific permission is set, it takes precedence over the global setting.
+2. If no schema-specific permission is found, the global setting (`ALLOW_X_OPERATION`) is used.
+3. In multi-DB mode, if a query doesn't specify a schema and one can't be determined from context, only read operations are allowed for safety.
+
+## Environment Variables Summary
+
+### Multi-DB Mode
+- `MYSQL_DB`: Leave empty to enable multi-DB mode
+- `MULTI_DB_WRITE_MODE`: Set to "true" to allow write operations in multi-DB mode without schema-specific permissions (not recommended for security)
+
+### Schema-Specific Permissions
+- `SCHEMA_INSERT_PERMISSIONS`: Control INSERT permissions per schema
+- `SCHEMA_UPDATE_PERMISSIONS`: Control UPDATE permissions per schema
+- `SCHEMA_DELETE_PERMISSIONS`: Control DELETE permissions per schema
+- `SCHEMA_DDL_PERMISSIONS`: Control DDL permissions per schema (CREATE, ALTER, DROP, TRUNCATE)
+
+### Global Permission Defaults
+- `ALLOW_INSERT_OPERATION`: Global default for INSERT permissions
+- `ALLOW_UPDATE_OPERATION`: Global default for UPDATE permissions
+- `ALLOW_DELETE_OPERATION`: Global default for DELETE permissions
+- `ALLOW_DDL_OPERATION`: Global default for DDL permissions
+
+## Security Considerations
+
+1. **Default to Principle of Least Privilege**: By default, all write operations are disabled globally and must be explicitly enabled.
+
+2. **Isolation in Multi-DB Mode**: Consider using a dedicated MySQL user with limited database grants when using multi-DB mode.
+
+3. **Careful with DDL Permissions**: DDL operations can modify database structure, so grant these permissions cautiously.
+
+4. **Production Databases**: Always set `schema:false` for production database schemas in all write permission settings.
+
+5. **User Least Privilege**: Ensure the MySQL user only has the required permissions on the specific databases needed.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A Model Context Protocol server that provides access to MySQL databases. This se
 - [Components](#components)
 - [Configuration](#configuration)
 - [Environment Variables](#environment-variables)
+- [Multi-DB Mode](#multi-db-mode)
+- [Schema-Specific Permissions](#schema-specific-permissions)
 - [Testing](#testing)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
@@ -348,7 +350,7 @@ For more control over the MCP server's behavior, you can use these advanced conf
 - `MYSQL_PORT`: MySQL server port (default: "3306")
 - `MYSQL_USER`: MySQL username (default: "root")
 - `MYSQL_PASS`: MySQL password
-- `MYSQL_DB`: Target database name
+- `MYSQL_DB`: Target database name (leave empty for multi-DB mode)
 
 ### Performance Configuration
 - `MYSQL_POOL_SIZE`: Connection pool size (default: "10")
@@ -362,11 +364,49 @@ For more control over the MCP server's behavior, you can use these advanced conf
 - `ALLOW_INSERT_OPERATION`: Enable INSERT operations (default: "false")
 - `ALLOW_UPDATE_OPERATION`: Enable UPDATE operations (default: "false")
 - `ALLOW_DELETE_OPERATION`: Enable DELETE operations (default: "false")
+- `ALLOW_DDL_OPERATION`: Enable DDL operations (default: "false")
+- `SCHEMA_INSERT_PERMISSIONS`: Schema-specific INSERT permissions
+- `SCHEMA_UPDATE_PERMISSIONS`: Schema-specific UPDATE permissions
+- `SCHEMA_DELETE_PERMISSIONS`: Schema-specific DELETE permissions
+- `SCHEMA_DDL_PERMISSIONS`: Schema-specific DDL permissions
+- `MULTI_DB_WRITE_MODE`: Enable write operations in multi-DB mode (default: "false")
 
 ### Monitoring Configuration
 - `MYSQL_ENABLE_LOGGING`: Enable query logging (default: "false")
 - `MYSQL_LOG_LEVEL`: Logging level (default: "info")
 - `MYSQL_METRICS_ENABLED`: Enable performance metrics (default: "false")
+
+## Multi-DB Mode
+
+MCP-Server-MySQL supports connecting to multiple databases when no specific database is set. This allows the LLM to query any database the MySQL user has access to. For full details, see [README-MULTI-DB.md](./README-MULTI-DB.md).
+
+### Enabling Multi-DB Mode
+
+To enable multi-DB mode, simply leave the `MYSQL_DB` environment variable empty. In multi-DB mode, queries require schema qualification:
+
+```sql
+-- Use fully qualified table names
+SELECT * FROM database_name.table_name;
+
+-- Or use USE statements to switch between databases
+USE database_name;
+SELECT * FROM table_name;
+```
+
+## Schema-Specific Permissions
+
+For fine-grained control over database operations, MCP-Server-MySQL now supports schema-specific permissions. This allows different databases to have different levels of access (read-only, read-write, etc.).
+
+### Configuration Example
+
+```
+SCHEMA_INSERT_PERMISSIONS=development:true,test:true,production:false
+SCHEMA_UPDATE_PERMISSIONS=development:true,test:true,production:false
+SCHEMA_DELETE_PERMISSIONS=development:false,test:true,production:false
+SCHEMA_DDL_PERMISSIONS=development:false,test:true,production:false
+```
+
+For complete details and security recommendations, see [README-MULTI-DB.md](./README-MULTI-DB.md).
 
 ## Testing
 

--- a/tests/integration/multi-db/multi-db-mode.test.ts
+++ b/tests/integration/multi-db/multi-db-mode.test.ts
@@ -1,0 +1,210 @@
+import * as mysql2 from 'mysql2/promise';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import * as dotenv from 'dotenv';
+import { executeReadOnlyQuery, executeWriteQuery } from '../../../dist/index.js';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// Set test directory path
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Create test environment for multi-DB mode
+describe('Multi-DB Mode', () => {
+  let pool: any;
+  
+  beforeAll(async () => {
+    // Mock environment variables for multi-DB mode
+    // Clear the database name to enable multi-DB mode
+    const originalDbName = process.env.MYSQL_DB;
+    process.env.MYSQL_DB = '';
+    
+    // Set write permissions to false for safety in multi-DB mode
+    process.env.ALLOW_INSERT_OPERATION = 'false';
+    process.env.ALLOW_UPDATE_OPERATION = 'false';
+    process.env.ALLOW_DELETE_OPERATION = 'false';
+    process.env.ALLOW_DDL_OPERATION = 'false';
+    
+    // Configure schema-specific permissions
+    process.env.SCHEMA_INSERT_PERMISSIONS = 'multi_db_test_1:true,multi_db_test_2:false';
+    
+    // Create connection pool for testing
+    const config: any = {
+      host: process.env.MYSQL_HOST || '127.0.0.1',
+      port: Number(process.env.MYSQL_PORT || '3306'),
+      user: process.env.MYSQL_USER || 'root',
+      connectionLimit: 5,
+      multipleStatements: true
+    };
+    
+    // Only add password if it's set
+    if (process.env.MYSQL_PASS) {
+      config.password = process.env.MYSQL_PASS;
+    }
+    
+    pool = mysql2.createPool(config);
+    
+    // Create test databases
+    const connection = await pool.getConnection();
+    try {
+      // Create test databases
+      await connection.query(`CREATE DATABASE IF NOT EXISTS multi_db_test_1`);
+      await connection.query(`CREATE DATABASE IF NOT EXISTS multi_db_test_2`);
+      
+      // Create test tables in each database
+      await connection.query(`
+        USE multi_db_test_1;
+        CREATE TABLE IF NOT EXISTS test_table (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          name VARCHAR(255) NOT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        
+        USE multi_db_test_2;
+        CREATE TABLE IF NOT EXISTS test_table (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          name VARCHAR(255) NOT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+      `);
+    } finally {
+      connection.release();
+    }
+    
+    return () => {
+      // Restore original DB name
+      if (originalDbName) {
+        process.env.MYSQL_DB = originalDbName;
+      } else {
+        delete process.env.MYSQL_DB;
+      }
+    };
+  });
+  
+  beforeEach(async () => {
+    // Reset test data before each test
+    const connection = await pool.getConnection();
+    try {
+      // Clear the tables in both databases
+      await connection.query(`
+        USE multi_db_test_1;
+        TRUNCATE TABLE test_table;
+        INSERT INTO test_table (name) VALUES ('DB 1 - Record 1'), ('DB 1 - Record 2');
+        
+        USE multi_db_test_2;
+        TRUNCATE TABLE test_table;
+        INSERT INTO test_table (name) VALUES ('DB 2 - Record 1'), ('DB 2 - Record 2');
+      `);
+    } finally {
+      connection.release();
+    }
+  });
+  
+  afterAll(async () => {
+    // Clean up test databases
+    const connection = await pool.getConnection();
+    try {
+      await connection.query(`
+        DROP DATABASE IF EXISTS multi_db_test_1;
+        DROP DATABASE IF EXISTS multi_db_test_2;
+      `);
+    } finally {
+      connection.release();
+    }
+    
+    // Close the pool
+    await pool.end();
+    
+    // Clean up environment variables
+    delete process.env.SCHEMA_INSERT_PERMISSIONS;
+  });
+  
+  // Test querying from multiple databases in multi-DB mode
+  it('should be able to query data from multiple databases', async () => {
+    // Query from first database
+    const result1 = await executeReadOnlyQuery(
+      'SELECT * FROM multi_db_test_1.test_table'
+    );
+    
+    expect(result1.isError).toBe(false);
+    const data1 = JSON.parse(result1.content[0].text);
+    expect(data1.length).toBe(2);
+    expect(data1[0].name).toBe('DB 1 - Record 1');
+    
+    // Query from second database
+    const result2 = await executeReadOnlyQuery(
+      'SELECT * FROM multi_db_test_2.test_table'
+    );
+    
+    expect(result2.isError).toBe(false);
+    const data2 = JSON.parse(result2.content[0].text);
+    expect(data2.length).toBe(2);
+    expect(data2[0].name).toBe('DB 2 - Record 1');
+  });
+  
+  // Test USE statement in multi-DB mode
+  it('should handle USE statements properly', async () => {
+    // Use the first database and then query without schema prefix
+    const result = await executeReadOnlyQuery(`
+      USE multi_db_test_1;
+      SELECT * FROM test_table;
+    `);
+    
+    expect(result.isError).toBe(false);
+    const data = JSON.parse(result.content[0].text);
+    expect(data.length).toBe(2);
+    expect(data[0].name).toBe('DB 1 - Record 1');
+  });
+  
+  // Test schema-specific permissions in multi-DB mode
+  it('should respect schema-specific permissions in multi-DB mode', async () => {
+    // Insert into allowed database (multi_db_test_1)
+    const result1 = await executeWriteQuery(
+      'INSERT INTO multi_db_test_1.test_table (name) VALUES ("New DB1 Record")'
+    );
+    
+    expect(result1.isError).toBe(false);
+    expect(result1.content[0].text).toContain('Insert successful');
+    
+    // Try insert into forbidden database (multi_db_test_2)
+    const result2 = await executeReadOnlyQuery(
+      'INSERT INTO multi_db_test_2.test_table (name) VALUES ("New DB2 Record")'
+    );
+    
+    expect(result2.isError).toBe(true);
+    expect(result2.content[0].text).toContain('INSERT operations are not allowed for schema');
+    
+    // Verify the records
+    const connection = await pool.getConnection();
+    try {
+      // Verify first insert succeeded
+      const [rows1] = await connection.query(
+        'SELECT * FROM multi_db_test_1.test_table WHERE name = ?',
+        ['New DB1 Record']
+      ) as [any[], any];
+      expect(rows1.length).toBe(1);
+      
+      // Verify second insert was blocked
+      const [rows2] = await connection.query(
+        'SELECT * FROM multi_db_test_2.test_table WHERE name = ?',
+        ['New DB2 Record']
+      ) as [any[], any];
+      expect(rows2.length).toBe(0);
+    } finally {
+      connection.release();
+    }
+  });
+  
+  // Test SHOW DATABASES command in multi-DB mode
+  it('should be able to list all databases', async () => {
+    const result = await executeReadOnlyQuery('SHOW DATABASES');
+    
+    expect(result.isError).toBe(false);
+    const databases = JSON.parse(result.content[0].text);
+    
+    // Check if our test databases are in the list
+    const dbNames = databases.map((db: any) => db.Database);
+    expect(dbNames).toContain('multi_db_test_1');
+    expect(dbNames).toContain('multi_db_test_2');
+  });
+});

--- a/tests/integration/schema-permissions/schema-permissions.test.ts
+++ b/tests/integration/schema-permissions/schema-permissions.test.ts
@@ -1,0 +1,256 @@
+import * as mysql2 from 'mysql2/promise';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import * as dotenv from 'dotenv';
+import { executeReadOnlyQuery, executeWriteQuery } from '../../../dist/index.js';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+// Set test directory path
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Create test environment for schema-specific permissions
+describe('Schema-specific Permissions', () => {
+  let pool: any;
+  
+  beforeAll(async () => {
+    // Mock environment variables for schema-specific permissions
+    process.env.ALLOW_INSERT_OPERATION = 'false';
+    process.env.ALLOW_UPDATE_OPERATION = 'false';
+    process.env.ALLOW_DELETE_OPERATION = 'false';
+    process.env.ALLOW_DDL_OPERATION = 'false';
+    
+    // Set schema-specific permissions
+    process.env.SCHEMA_INSERT_PERMISSIONS = 'test_schema_1:true,test_schema_2:false';
+    process.env.SCHEMA_UPDATE_PERMISSIONS = 'test_schema_1:false,test_schema_2:true';
+    process.env.SCHEMA_DELETE_PERMISSIONS = 'test_schema_1:true,test_schema_2:false';
+    process.env.SCHEMA_DDL_PERMISSIONS = 'test_schema_1:true,test_schema_2:false';
+    
+    // Create connection pool for testing
+    const config: any = {
+      host: process.env.MYSQL_HOST || '127.0.0.1',
+      port: Number(process.env.MYSQL_PORT || '3306'),
+      user: process.env.MYSQL_USER || 'root',
+      connectionLimit: 5,
+      multipleStatements: true
+    };
+    
+    // Only add password if it's set
+    if (process.env.MYSQL_PASS) {
+      config.password = process.env.MYSQL_PASS;
+    }
+    
+    pool = mysql2.createPool(config);
+    
+    // Create test schemas
+    const connection = await pool.getConnection();
+    try {
+      // Create test schemas
+      await connection.query(`CREATE DATABASE IF NOT EXISTS test_schema_1`);
+      await connection.query(`CREATE DATABASE IF NOT EXISTS test_schema_2`);
+      
+      // Create test tables in each schema
+      await connection.query(`
+        USE test_schema_1;
+        CREATE TABLE IF NOT EXISTS test_table (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          name VARCHAR(255) NOT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        
+        USE test_schema_2;
+        CREATE TABLE IF NOT EXISTS test_table (
+          id INT AUTO_INCREMENT PRIMARY KEY,
+          name VARCHAR(255) NOT NULL,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+      `);
+    } finally {
+      connection.release();
+    }
+  });
+  
+  beforeEach(async () => {
+    // Reset test data before each test
+    const connection = await pool.getConnection();
+    try {
+      // Clear the tables in both schemas
+      await connection.query(`
+        USE test_schema_1;
+        TRUNCATE TABLE test_table;
+        INSERT INTO test_table (name) VALUES ('Schema 1 - Test 1'), ('Schema 1 - Test 2');
+        
+        USE test_schema_2;
+        TRUNCATE TABLE test_table;
+        INSERT INTO test_table (name) VALUES ('Schema 2 - Test 1'), ('Schema 2 - Test 2');
+      `);
+    } finally {
+      connection.release();
+    }
+  });
+  
+  afterAll(async () => {
+    // Clean up test schemas
+    const connection = await pool.getConnection();
+    try {
+      await connection.query(`
+        DROP DATABASE IF EXISTS test_schema_1;
+        DROP DATABASE IF EXISTS test_schema_2;
+      `);
+    } finally {
+      connection.release();
+    }
+    
+    // Close the pool
+    await pool.end();
+    
+    // Clean up environment variables
+    delete process.env.SCHEMA_INSERT_PERMISSIONS;
+    delete process.env.SCHEMA_UPDATE_PERMISSIONS;
+    delete process.env.SCHEMA_DELETE_PERMISSIONS;
+    delete process.env.SCHEMA_DDL_PERMISSIONS;
+  });
+  
+  // Test INSERT permission for schema_1 (allowed)
+  it('should allow INSERT operations for test_schema_1', async () => {
+    const result = await executeWriteQuery(
+      'INSERT INTO test_schema_1.test_table (name) VALUES ("New Record")'
+    );
+    
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('Insert successful');
+    
+    // Verify the record was inserted
+    const connection = await pool.getConnection();
+    try {
+      const [rows] = await connection.query(
+        'SELECT * FROM test_schema_1.test_table WHERE name = ?', 
+        ['New Record']
+      ) as [any[], any];
+      
+      expect(rows.length).toBe(1);
+    } finally {
+      connection.release();
+    }
+  });
+  
+  // Test INSERT permission for schema_2 (not allowed)
+  it('should block INSERT operations for test_schema_2', async () => {
+    const result = await executeReadOnlyQuery(
+      'INSERT INTO test_schema_2.test_table (name) VALUES ("Blocked Insert")'
+    );
+    
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('INSERT operations are not allowed for schema');
+    
+    // Verify the record was not inserted
+    const connection = await pool.getConnection();
+    try {
+      const [rows] = await connection.query(
+        'SELECT * FROM test_schema_2.test_table WHERE name = ?', 
+        ['Blocked Insert']
+      ) as [any[], any];
+      
+      expect(rows.length).toBe(0); // Record should not exist
+    } finally {
+      connection.release();
+    }
+  });
+  
+  // Test UPDATE permission for schema_1 (not allowed)
+  it('should block UPDATE operations for test_schema_1', async () => {
+    const result = await executeReadOnlyQuery(
+      'UPDATE test_schema_1.test_table SET name = "Updated Name" WHERE name = "Schema 1 - Test 1"'
+    );
+    
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('UPDATE operations are not allowed for schema');
+    
+    // Verify the record was not updated
+    const connection = await pool.getConnection();
+    try {
+      const [rows] = await connection.query(
+        'SELECT * FROM test_schema_1.test_table WHERE name = ?', 
+        ['Schema 1 - Test 1']
+      ) as [any[], any];
+      
+      expect(rows.length).toBe(1); // Original record should still exist
+    } finally {
+      connection.release();
+    }
+  });
+  
+  // Test UPDATE permission for schema_2 (allowed)
+  it('should allow UPDATE operations for test_schema_2', async () => {
+    const result = await executeWriteQuery(
+      'UPDATE test_schema_2.test_table SET name = "Updated Name" WHERE name = "Schema 2 - Test 1"'
+    );
+    
+    expect(result.isError).toBe(false);
+    expect(result.content[0].text).toContain('Update successful');
+    
+    // Verify the record was updated
+    const connection = await pool.getConnection();
+    try {
+      const [rows] = await connection.query(
+        'SELECT * FROM test_schema_2.test_table WHERE name = ?', 
+        ['Updated Name']
+      ) as [any[], any];
+      
+      expect(rows.length).toBe(1); // Updated record should exist
+    } finally {
+      connection.release();
+    }
+  });
+  
+  // Test DDL permission for schema_1 (allowed)
+  it('should allow DDL operations for test_schema_1', async () => {
+    const result = await executeWriteQuery(
+      'ALTER TABLE test_schema_1.test_table ADD COLUMN test_column VARCHAR(50)'
+    );
+    
+    expect(result.isError).toBe(false);
+    
+    // Verify the column was added
+    const connection = await pool.getConnection();
+    try {
+      const [columns] = await connection.query(
+        `SELECT COLUMN_NAME 
+         FROM INFORMATION_SCHEMA.COLUMNS 
+         WHERE TABLE_SCHEMA = 'test_schema_1' 
+         AND TABLE_NAME = 'test_table'
+         AND COLUMN_NAME = 'test_column'`
+      ) as [any[], any];
+      
+      expect(columns.length).toBe(1); // Column should exist
+    } finally {
+      connection.release();
+    }
+  });
+  
+  // Test DDL permission for schema_2 (not allowed)
+  it('should block DDL operations for test_schema_2', async () => {
+    const result = await executeReadOnlyQuery(
+      'ALTER TABLE test_schema_2.test_table ADD COLUMN test_column VARCHAR(50)'
+    );
+    
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('DDL operations are not allowed for schema');
+    
+    // Verify the column was not added
+    const connection = await pool.getConnection();
+    try {
+      const [columns] = await connection.query(
+        `SELECT COLUMN_NAME 
+         FROM INFORMATION_SCHEMA.COLUMNS 
+         WHERE TABLE_SCHEMA = 'test_schema_2' 
+         AND TABLE_NAME = 'test_table'
+         AND COLUMN_NAME = 'test_column'`
+      ) as [any[], any];
+      
+      expect(columns.length).toBe(0); // Column should not exist
+    } finally {
+      connection.release();
+    }
+  });
+});


### PR DESCRIPTION

# Pull Request: Multi-DB Support and Schema-Specific Permissions

## Summary

This PR adds two major features to the MCP-Server-MySQL:

1. **Multi-Database Mode** - Allows connecting to multiple databases when no specific database name is provided
2. **Schema-Specific Permissions** - Enables fine-grained control over database operations on a per-schema basis

These changes address the limitation where the server could only connect to a single database at a time, which was hindering progress on several projects.

## Changes

### New Features

- **Multi-DB Mode**
  - When `MYSQL_DB` is empty, the server can connect to all databases the MySQL user has access to
  - Enhanced resource listing to show tables from all available databases
  - Improved query parsing to extract schema context
  - Default read-only safety for multi-DB mode

- **Schema-Specific Permissions**
  - Added environment variables for schema-specific permissions:
    - `SCHEMA_INSERT_PERMISSIONS`
    - `SCHEMA_UPDATE_PERMISSIONS`
    - `SCHEMA_DELETE_PERMISSIONS`
    - `SCHEMA_DDL_PERMISSIONS`
  - Fine-grained permission control using format: `database1:true,database2:false`
  - Schema context detection for better error messages

- **DDL Operations Support**
  - Added support for Data Definition Language operations (CREATE, ALTER, DROP, TRUNCATE)
  - New `ALLOW_DDL_OPERATION` global permission flag
  - Schema-specific DDL permissions

### Implementation Details

- Modified `index.ts` to support multi-DB connections and schema-specific permissions
- Enhanced SQL query parser to extract schema context from queries
- Updated response messages to include schema context
- Added comprehensive test coverage for new features
- Created detailed documentation

### Documentation

- Updated main README.md with information about new features
- Added detailed README-MULTI-DB.md with comprehensive documentation
- Updated environment variables documentation
- Added example configurations

## Testing

Added new test cases:
- Integration tests for schema-specific permissions
- Integration tests for multi-DB mode functionality
- Both positive and negative test cases to verify permission enforcement

## Security Considerations

- Multi-DB mode defaults to read-only for safety
- Write operations in multi-DB mode require explicit schema permissions
- Added documentation with security best practices
- Schema extraction fallback maintains safety

## Backwards Compatibility

This change is fully backwards compatible. Existing configurations will continue to work as before, with the new features being opt-in.
