### PR TITLE
TS2451 Cannot redeclare block-scoped variable

### DIFF
--- a/evals.ts
+++ b/evals.ts
@@ -13,7 +13,7 @@ const mysql_queryEval: EvalFunction = {
     }
 };
 
-const mysql_queryEval: EvalFunction = {
+const mysql_queryEval2: EvalFunction = {
     name: 'mysql_query Tool Evaluation',
     description: 'Evaluates the MySQL query tool for correct SQL generation and execution',
     run: async () => {
@@ -22,7 +22,7 @@ const mysql_queryEval: EvalFunction = {
     }
 };
 
-const mysql_queryEval: EvalFunction = {
+const mysql_queryEval3: EvalFunction = {
     name: 'mysql_queryEval',
     description: 'Evaluates the mysql_query tool',
     run: async () => {
@@ -33,9 +33,9 @@ const mysql_queryEval: EvalFunction = {
 
 const config: EvalConfig = {
     model: openai("gpt-4"),
-    evals: [mysql_queryEval, mysql_queryEval, mysql_queryEval]
+    evals: [mysql_queryEval, mysql_queryEval2, mysql_queryEval3]
 };
   
 export default config;
   
-export const evals = [mysql_queryEval, mysql_queryEval, mysql_queryEval];
+export const evals = [mysql_queryEval, mysql_queryEval2, mysql_queryEval3];


### PR DESCRIPTION
Describe the bug
The project fails to build when running npm run build. The TypeScript compiler (tsc) throws multiple errors of type TS2451: Cannot redeclare block-scoped variable 'mysql_queryEval' within the evals.ts file. This indicates that the variable mysql_queryEval is being declared multiple times in the same scope.

Platform
macOS: 15.4.1
Npm: 10.2.4
Node: v20.11.1

Screenshots
![image](https://github.com/user-attachments/assets/dd8e23c7-504a-43ca-9b6e-e3242213b0bc)


Additional context
The build command npm run build executes tsc && shx chmod +x dist/*.js. The failure occurs during the tsc (TypeScript compilation) step.