### PR TITLE
refactor: improve formatting and organization in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,19 +332,19 @@ To run in remote mode, you'll need to provide [environment variables](https://gi
 
 9. Configure your agent to connect to the MCP with the next configuration:
 
-  ```json
-  {
-    "mcpServers": {
-      "mysql": {
-        "url": "http://your-host:3000/mcp",
-        "type": "streamableHttp",
-        "headers": {
-          "Authorization": "Bearer <REMOTE_SECRET_KEY>"
-        }
-      }
-    }
-  }
-  ```
+   ```json
+   {
+     "mcpServers": {
+       "mysql": {
+         "url": "http://your-host:3000/mcp",
+         "type": "streamableHttp",
+         "headers": {
+           "Authorization": "Bearer <REMOTE_SECRET_KEY>"
+         }
+       }
+     }
+   }
+   ```
 
 ## Components
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ A Model Context Protocol server that provides access to MySQL databases. This se
 
 ### Using Smithery
 
-There are several ways to install and configure the MCP server but the most common would be checking this website https://smithery.ai/server/@benborla29/mcp-server-mysql
+There are several ways to install and configure the MCP server but the most common would be checking this website [https://smithery.ai/server/@benborla29/mcp-server-mysql](https://smithery.ai/server/@benborla29/mcp-server-mysql)
 
 ### Cursor
 
 For Cursor IDE, you can install this MCP server with the following command in your project:
 
-1. Visit https://smithery.ai/server/@benborla29/mcp-server-mysql
+1. Visit [https://smithery.ai/server/@benborla29/mcp-server-mysql](https://smithery.ai/server/@benborla29/mcp-server-mysql)
 2. Follow the instruction for Cursor
 
 MCP Get provides a centralized registry of MCP servers and simplifies the installation process.
@@ -304,7 +304,7 @@ If you want to clone and run this MCP server directly from the source code, foll
 
 ### Run in remote mode
 
-To run in remote mode, you'll need to provide [environment variables](https://github.com/benborla/mcp-server-mysql?tab=readme-ov-file#environment-variables) to the npx script. 
+To run in remote mode, you'll need to provide [environment variables](https://github.com/benborla/mcp-server-mysql?tab=readme-ov-file#environment-variables) to the npx script.
 
 1. Create env file in preferred directory
 
@@ -613,7 +613,7 @@ pnpm test
 
 ## Running evals
 
-The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found at [MCP Evals](https://www.mcpevals.io/docs).
 
 ```bash
 OPENAI_API_KEY=your-key  npx mcp-eval evals.ts index.ts
@@ -731,7 +731,7 @@ OPENAI_API_KEY=your-key  npx mcp-eval evals.ts index.ts
 Contributions are welcome! Please feel free to submit a Pull Request to
 [https://github.com/benborla/mcp-server-mysql](https://github.com/benborla/mcp-server-mysql)
 
-## Many Thanks to the following Contributors:
+## Many Thanks to the following Contributors
 
 [![Contributors](https://contrib.rocks/image?repo=benborla/mcp-server-mysql)](https://github.com/benborla/mcp-server-mysql/graphs/contributors)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-
 # MCP Server for MySQL based on NodeJS
-
 
 A Model Context Protocol server that provides access to MySQL databases. This server enables LLMs to inspect database schemas and execute SQL queries.
 
 ## Table of Contents
+
 - [Requirements](#requirements)
 - [Installation](#installation)
   - [Smithery](#using-smithery)
@@ -29,6 +28,8 @@ A Model Context Protocol server that provides access to MySQL databases. This se
 
 ## Installation
 
+### Using Smithery
+
 There are several ways to install and configure the MCP server but the most common would be checking this website https://smithery.ai/server/@benborla29/mcp-server-mysql
 
 ### Cursor
@@ -37,7 +38,6 @@ For Cursor IDE, you can install this MCP server with the following command in yo
 
 1. Visit https://smithery.ai/server/@benborla29/mcp-server-mysql
 2. Follow the instruction for Cursor
-
 
 MCP Get provides a centralized registry of MCP servers and simplifies the installation process.
 
@@ -58,6 +58,7 @@ This will show an interactive dialog where you can select your `mcp_server_mysql
 **Using NPM/PNPM Global Installation:**
 
 First, install the package globally:
+
 ```bash
 # Using npm
 npm install -g @benborla29/mcp-server-mysql
@@ -67,6 +68,7 @@ pnpm add -g @benborla29/mcp-server-mysql
 ```
 
 Then add the server to Claude Code:
+
 ```bash
 claude mcp add mcp_server_mysql \
   -e MYSQL_HOST="127.0.0.1" \
@@ -83,6 +85,7 @@ claude mcp add mcp_server_mysql \
 **Using Local Repository (for development):**
 
 If you're running from a cloned repository:
+
 ```bash
 claude mcp add mcp_server_mysql \
   -e MYSQL_HOST="127.0.0.1" \
@@ -99,6 +102,7 @@ claude mcp add mcp_server_mysql \
 ```
 
 Replace:
+
 - `/path/to/node` with your Node.js binary path (find with `which node`)
 - `/full/path/to/mcp-server-mysql` with the full path to your cloned repository
 - Update MySQL credentials to match your environment
@@ -106,6 +110,7 @@ Replace:
 **Using Unix Socket Connection:**
 
 For local MySQL instances using Unix sockets:
+
 ```bash
 claude mcp add mcp_server_mysql \
   -e MYSQL_SOCKET_PATH="/tmp/mysql.sock" \
@@ -192,6 +197,7 @@ claude mcp add mcp_server_mysql \
 1. **Server Connection Issues**: Use `/mcp` command in Claude Code to check server status and authenticate if needed.
 
 2. **Path Issues**: If using a local repository, ensure Node.js paths are correctly set:
+
    ```bash
    # Find your Node.js path
    which node
@@ -206,6 +212,7 @@ claude mcp add mcp_server_mysql \
 3. **Permission Errors**: Ensure your MySQL user has appropriate permissions for the operations you've enabled.
 
 4. **Server Not Starting**: Check Claude Code logs or run the server directly to debug:
+
    ```bash
    # Test the server directly
    npx @benborla29/mcp-server-mysql
@@ -230,12 +237,14 @@ After manual installation, you'll need to configure your LLM application to use 
 If you want to clone and run this MCP server directly from the source code, follow these steps:
 
 1. **Clone the repository**
+
    ```bash
    git clone https://github.com/benborla/mcp-server-mysql.git
    cd mcp-server-mysql
    ```
 
 2. **Install dependencies**
+
    ```bash
    npm install
    # or
@@ -243,6 +252,7 @@ If you want to clone and run this MCP server directly from the source code, foll
    ```
 
 3. **Build the project**
+
    ```bash
    npm run build
    # or
@@ -284,6 +294,7 @@ If you want to clone and run this MCP server directly from the source code, foll
    - Set the MySQL credentials to match your environment
 
 5. **Test the server**
+
    ```bash
    # Run the server directly to test
    node dist/index.js
@@ -294,39 +305,46 @@ If you want to clone and run this MCP server directly from the source code, foll
 ### Run in remote mode
 
 To run in remote mode, you'll need to provide [environment variables](https://github.com/benborla/mcp-server-mysql?tab=readme-ov-file#environment-variables) to the npx script. 
+
 1. Create env file in preferred directory
+
    ```bash
    # create .env file
    touch .env
    ```
+
 2. Copy-paste [example file](https://github.com/benborla/mcp-server-mysql/blob/main/.env) from this repository
 3. Set the MySQL credentials to match your environment
 4. Set `IS_REMOTE_MCP=true`
 5. Set `REMOTE_SECRET_KEY` to a secure string.
 6. Provide custom `PORT` if needed. Default is 3000.
 7. Load variables in current session:
+
    ```bash
    source .env
    ```
+
 8. Run the server
+
    ```bash
    npx @benborla29/mcp-server-mysql
    ```
+
 9. Configure your agent to connect to the MCP with the next configuration:
-```json
-{
-  "mcpServers": {
-    "mysql": {
-      "url": "http://your-host:3000/mcp",
-      "type": "streamableHttp",
-      "headers": {
-        "Authorization": "Bearer <REMOTE_SECRET_KEY>"
+
+  ```json
+  {
+    "mcpServers": {
+      "mysql": {
+        "url": "http://your-host:3000/mcp",
+        "type": "streamableHttp",
+        "headers": {
+          "Authorization": "Bearer <REMOTE_SECRET_KEY>"
+        }
       }
     }
   }
-}
-```
-
+  ```
 
 ## Components
 
@@ -385,6 +403,7 @@ The server provides comprehensive database information:
 ## Configuration
 
 ### Automatic Configuration with Smithery
+
 If you installed using Smithery, your configuration is already set up. You can view or modify it with:
 
 ```bash
@@ -405,6 +424,7 @@ When reconfiguring, you can update any of the MySQL connection details as well a
 For security reasons, all write operations are disabled by default. Only enable these settings if you specifically need Claude to modify your database data.
 
 ### Advanced Configuration Options
+
 For more control over the MCP server's behavior, you can use these advanced configuration options:
 
 ```json
@@ -453,6 +473,7 @@ For more control over the MCP server's behavior, you can use these advanced conf
 ## Environment Variables
 
 ### Basic Connection
+
 - `MYSQL_SOCKET_PATH`: Unix socket path for local connections (e.g., "/tmp/mysql.sock")
 - `MYSQL_HOST`: MySQL server host (default: "127.0.0.1") - ignored if MYSQL_SOCKET_PATH is set
 - `MYSQL_PORT`: MySQL server port (default: "3306") - ignored if MYSQL_SOCKET_PATH is set
@@ -461,11 +482,13 @@ For more control over the MCP server's behavior, you can use these advanced conf
 - `MYSQL_DB`: Target database name (leave empty for multi-DB mode)
 
 ### Performance Configuration
+
 - `MYSQL_POOL_SIZE`: Connection pool size (default: "10")
 - `MYSQL_QUERY_TIMEOUT`: Query timeout in milliseconds (default: "30000")
 - `MYSQL_CACHE_TTL`: Cache time-to-live in milliseconds (default: "60000")
 
 ### Security Configuration
+
 - `MYSQL_RATE_LIMIT`: Maximum queries per minute (default: "100")
 - `MYSQL_MAX_QUERY_COMPLEXITY`: Maximum query complexity score (default: "1000")
 - `MYSQL_SSL`: Enable SSL/TLS encryption (default: "false")
@@ -480,11 +503,13 @@ For more control over the MCP server's behavior, you can use these advanced conf
 - `MULTI_DB_WRITE_MODE`: Enable write operations in multi-DB mode (default: "false")
 
 ### Monitoring Configuration
+
 - `MYSQL_ENABLE_LOGGING`: Enable query logging (default: "false")
 - `MYSQL_LOG_LEVEL`: Logging level (default: "info")
 - `MYSQL_METRICS_ENABLED`: Enable performance metrics (default: "false")
 
 ### Remote MCP Configuration
+
 - `IS_REMOTE_MCP`: Enable remote MCP mode (default: "false")
 - `REMOTE_SECRET_KEY`: Secret key for remote MCP authentication (default: ""). If not provided, remote MCP mode will be disabled.
 - `PORT`: Port number for the remote MCP server (default: 3000)
@@ -512,7 +537,7 @@ For fine-grained control over database operations, MCP-Server-MySQL now supports
 
 ### Configuration Example
 
-```
+```txt
 SCHEMA_INSERT_PERMISSIONS=development:true,test:true,production:false
 SCHEMA_UPDATE_PERMISSIONS=development:true,test:true,production:false
 SCHEMA_DELETE_PERMISSIONS=development:false,test:true,production:false
@@ -528,6 +553,7 @@ For complete details and security recommendations, see [README-MULTI-DB.md](./RE
 Before running tests, you need to set up the test database and seed it with test data:
 
 1. **Create Test Database and User**
+
    ```sql
    -- Connect as root and create test database
    CREATE DATABASE IF NOT EXISTS mcp_test;
@@ -539,6 +565,7 @@ Before running tests, you need to set up the test database and seed it with test
    ```
 
 2. **Run Database Setup Script**
+
    ```bash
    # Run the database setup script
    pnpm run setup:test:db
@@ -548,6 +575,7 @@ Before running tests, you need to set up the test database and seed it with test
 
 3. **Configure Test Environment**
    Create a `.env.test` file in the project root (if not existing):
+
    ```env
    MYSQL_HOST=127.0.0.1
    MYSQL_PORT=3306
@@ -558,6 +586,7 @@ Before running tests, you need to set up the test database and seed it with test
 
 4. **Update package.json Scripts**
    Add these scripts to your package.json:
+
    ```json
    {
      "scripts": {
@@ -582,8 +611,6 @@ pnpm run setup:test:db
 pnpm test
 ```
 
-
-
 ## Running evals
 
 The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
@@ -591,6 +618,7 @@ The evals package loads an mcp client that then runs the index.ts file, so there
 ```bash
 OPENAI_API_KEY=your-key  npx mcp-eval evals.ts index.ts
 ```
+
 ## Troubleshooting
 
 ### Common Issues
@@ -615,27 +643,30 @@ OPENAI_API_KEY=your-key  npx mcp-eval evals.ts index.ts
    - Ensure the user has appropriate MySQL permissions
 
 4. **Path Resolution**
-If you encounter an error "Could not connect to MCP server mcp-server-mysql", explicitly set the path of all required binaries:
-```json
-{
-  "env": {
-    "PATH": "/path/to/node/bin:/usr/bin:/bin"
-  }
-}
-```
+   If you encounter an error "Could not connect to MCP server mcp-server-mysql", explicitly set the path of all required binaries:
 
-*Where can I find my `node` bin path*
-Run the following command to get it:
+   ```json
+   {
+     "env": {
+       "PATH": "/path/to/node/bin:/usr/bin:/bin"
+     }
+   }
+   ```
 
-For **PATH**
-```bash
-echo "$(which node)/../"
-```
+   *Where can I find my `node` bin path*
+   Run the following command to get it:
 
-For **NODE_PATH**
-```bash
-echo "$(which node)/../../lib/node_modules"
-```
+   For **PATH**
+
+   ```bash
+   echo "$(which node)/../"
+   ```
+
+   For **NODE_PATH**
+
+   ```bash
+   echo "$(which node)/../../lib/node_modules"
+   ```
 
 5. **Claude Desktop Specific Issues**
    - If you see "Server disconnected" logs in Claude Desktop, check the logs at `~/Library/Logs/Claude/mcp-server-mcp_server_mysql.log`
@@ -643,6 +674,7 @@ echo "$(which node)/../../lib/node_modules"
    - Check if your `.env` file is being properly loaded; use explicit environment variables in the configuration
    - Try running the server directly from the command line to see if there are connection issues
    - If you need write operations (INSERT, UPDATE, DELETE), set the appropriate flags to "true" in your configuration:
+
      ```json
      "env": {
        "ALLOW_INSERT_OPERATION": "true",  // Enable INSERT operations
@@ -650,8 +682,10 @@ echo "$(which node)/../../lib/node_modules"
        "ALLOW_DELETE_OPERATION": "true"   // Enable DELETE operations
      }
      ```
+
    - Ensure your MySQL user has the appropriate permissions for the operations you're enabling
    - For direct execution configuration, use:
+
      ```json
      {
        "mcpServers": {
@@ -676,27 +710,30 @@ echo "$(which node)/../../lib/node_modules"
    - For MySQL 8.0+, ensure the server supports the `caching_sha2_password` authentication plugin
    - Check if your MySQL user is configured with the correct authentication method
    - Try creating a user with legacy authentication if needed:
+
      ```sql
      CREATE USER 'user'@'localhost' IDENTIFIED WITH mysql_native_password BY 'password';
      ```
+
      @lizhuangs
 
 7. I am encountering `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'dotenv' imported from` error
-try this workaround:
-```bash
-npx -y -p @benborla29/mcp-server-mysql -p dotenv mcp-server-mysql
-```
-Thanks to @lizhuangs
+   try this workaround:
+
+   ```bash
+   npx -y -p @benborla29/mcp-server-mysql -p dotenv mcp-server-mysql
+   ```
+
+   Thanks to @lizhuangs
 
 ## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request to
-https://github.com/benborla/mcp-server-mysql
+[https://github.com/benborla/mcp-server-mysql](https://github.com/benborla/mcp-server-mysql)
 
 ## Many Thanks to the following Contributors:
-<a href = "https://github.com/benborla/mcp-server-mysql/graphs/contributors">
-  <img src = "https://contrib.rocks/image?repo=benborla/mcp-server-mysql"/>
-</a>
+
+[![Contributors](https://contrib.rocks/image?repo=benborla/mcp-server-mysql)](https://github.com/benborla/mcp-server-mysql/graphs/contributors)
 
 ### Development Setup
 


### PR DESCRIPTION
- Cleaned up markdown formatting to align with most modern markdown linters *(remove the squiggly lines)*
- Fixed broken link for the `[Smithery](#using-smithery)` sub section of `[Installation](#installation)` section by adding a `### Using Smithery` heading under the `## Installation` heading.
- Changed html anchor link to proper markdown linking format.

Clean markdown is sexy markdown... am I right?