### PR TITLE
feat: Update Dockerfile to use yarn for building and add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+*.log
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ COPY package.json pnpm-lock.yaml* /app/
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy the rest of the application code
-COPY . /app
+COPY . .
 
 # Build the application
-RUN pnpm run build
+RUN yarn build
 
 # Use a new, clean image for the release
 FROM node:22-alpine


### PR DESCRIPTION
This pull request introduces improvements to the Docker build process and environment setup for the project. The most important changes include updating the Dockerfile to use `yarn` for building instead of `pnpm`, refining the copy commands for better context handling, and adding a `.dockerignore` file to exclude unnecessary files from the build context.

**Dockerfile improvements:**

* Switched the build command from `pnpm run build` to `yarn build` to standardize the build process.
* Changed the copy command from `COPY . /app` to `COPY . .` for better context handling and consistency.

**Environment and build context optimization:**

* Added a `.dockerignore` file to exclude `node_modules`, `dist`, log files, and `.env` from the Docker build context, reducing image size and build time.