### PR TITLE
fix: Add connection pool keep-alive settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,8 @@ For more control over the MCP server's behavior, you can use these advanced conf
 - `MYSQL_POOL_SIZE`: Connection pool size (default: "10")
 - `MYSQL_QUERY_TIMEOUT`: Query timeout in milliseconds (default: "30000")
 - `MYSQL_CACHE_TTL`: Cache time-to-live in milliseconds (default: "60000")
+- `MYSQL_QUEUE_LIMIT`: Maximum number of queued connection requests (default: "100")
+- `MYSQL_CONNECT_TIMEOUT`: Connection timeout in milliseconds (default: "10000")
 
 ### Security Configuration
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -66,6 +66,11 @@ export const mcpConfig = {
       process.env.MYSQL_PASS === undefined ? "" : process.env.MYSQL_PASS,
     database: process.env.MYSQL_DB || undefined, // Allow undefined database for multi-DB mode
     connectionLimit: 10,
+    waitForConnections: true,
+    queueLimit: process.env.MYSQL_QUEUE_LIMIT ? parseInt(process.env.MYSQL_QUEUE_LIMIT, 10) : 100,
+    enableKeepAlive: true,
+    keepAliveInitialDelay: 0,
+    connectTimeout: process.env.MYSQL_CONNECT_TIMEOUT ? parseInt(process.env.MYSQL_CONNECT_TIMEOUT, 10) : 10000,
     authPlugins: {
       mysql_clear_password: () => () =>
         Buffer.from(process.env.MYSQL_PASS || "root"),


### PR DESCRIPTION
## Summary

Adds connection pool configuration options to prevent connection timeouts, especially useful for long-running connections or connections through proxies that may timeout idle connections.

## Changes

### Configuration Options Added
- `waitForConnections: true` - Queue connection requests when pool is full instead of immediately erroring
- `queueLimit: 100` (default, configurable) - Limits queued requests to prevent unbounded memory growth
- `enableKeepAlive: true` - Enable TCP keep-alive packets
- `keepAliveInitialDelay: 0` - Start keep-alive checks immediately
- `connectTimeout: 10000ms` (default, configurable) - 10 second connection timeout for better UX

### Environment Variables
- `MYSQL_QUEUE_LIMIT` - Override default queue limit (default: 100)
- `MYSQL_CONNECT_TIMEOUT` - Override connect timeout in milliseconds (default: 10000)

## Use Cases

This addresses connection stability issues when:
- Running long-lived MCP server instances
- Connecting through proxies with idle connection timeouts
- Database servers behind load balancers or connection pools
- Network conditions with intermittent connectivity

## Code Quality

- ✅ CodeRabbit review passed with no issues
- ✅ Configurable via environment variables
- ✅ Sensible defaults to prevent resource exhaustion

## Testing

Tested with staging MySQL connection through proxy that times out idle connections after 1 hour. Keep-alive settings maintain stable connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>