### PR TITLE
feat: Add MYSQL_TIMEZONE and MYSQL_DATE_STRINGS configuration options

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -37,6 +37,13 @@ MULTI_DB_WRITE_MODE=false
 MYSQL_SSL=false
 MYSQL_SSL_REJECT_UNAUTHORIZED=true
 
+# Timezone and date handling
+# Set timezone for date/time values (e.g., "+08:00" for UTC+8, "Z" for UTC, "local" for system timezone)
+# MYSQL_TIMEZONE=+08:00
+# Return date/datetime values as strings instead of JavaScript Date objects
+# Useful for preserving exact database values without timezone conversion
+# MYSQL_DATE_STRINGS=false
+
 # Performance settings
 MYSQL_POOL_SIZE=10
 MYSQL_QUERY_TIMEOUT=30000

--- a/README.md
+++ b/README.md
@@ -541,6 +541,14 @@ When `MYSQL_CONNECTION_STRING` is provided, it takes precedence over individual 
 - `SCHEMA_DDL_PERMISSIONS`: Schema-specific DDL permissions
 - `MULTI_DB_WRITE_MODE`: Enable write operations in multi-DB mode (default: "false")
 
+### Timezone and Date Configuration
+
+- `MYSQL_TIMEZONE`: Set the timezone for date/time values. Accepts formats like `+08:00` (UTC+8), `-05:00` (UTC-5), `Z` (UTC), or `local` (system timezone). Useful for ensuring consistent date/time handling across different server locations.
+- `MYSQL_DATE_STRINGS`: When set to `"true"`, returns date/datetime values as strings instead of JavaScript Date objects. This preserves the exact database values without any timezone conversion, which is particularly useful for:
+  - Applications that need precise control over date formatting
+  - Cross-timezone database operations
+  - Avoiding JavaScript Date timezone quirks
+
 ### Monitoring Configuration
 
 - `MYSQL_ENABLE_LOGGING`: Enable query logging (default: "false")

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -100,6 +100,18 @@ export const mcpConfig = {
           },
         }
       : {}),
+    // Timezone configuration for date/time handling
+    ...(process.env.MYSQL_TIMEZONE
+      ? {
+          timezone: process.env.MYSQL_TIMEZONE,
+        }
+      : {}),
+    // Return date values as strings instead of JavaScript Date objects
+    ...(process.env.MYSQL_DATE_STRINGS === "true"
+      ? {
+          dateStrings: true,
+        }
+      : {}),
   },
   paths: {
     schema: "schema",


### PR DESCRIPTION
## Summary

This PR adds two new environment variables for timezone and date handling configuration:

- **`MYSQL_TIMEZONE`**: Set the timezone for date/time values
  - Accepts formats like `+08:00` (UTC+8), `-05:00` (UTC-5), `Z` (UTC), or `local` (system timezone)
  - Useful for ensuring consistent date/time handling across different server locations

- **`MYSQL_DATE_STRINGS`**: When set to `"true"`, returns date/datetime values as strings instead of JavaScript Date objects
  - Preserves exact database values without any timezone conversion
  - Particularly useful for cross-timezone operations and avoiding JavaScript Date quirks

## Use Cases

1. **Cross-timezone database operations**: Ensuring consistent date/time handling when server and database are in different timezones
2. **Precise date formatting**: Applications that need exact control over date values
3. **Avoiding JavaScript Date issues**: Preventing automatic timezone conversion by JavaScript Date objects

## Changes

- `src/config/index.ts`: Added timezone and dateStrings configuration options to MySQL connection
- `.env.dist`: Added documentation and examples for new environment variables
- `README.md`: Added "Timezone and Date Configuration" section under Environment Variables

## Example Configuration

```bash
# Set timezone to UTC+8 (e.g., Beijing, Singapore)
MYSQL_TIMEZONE=+08:00

# Return date values as strings
MYSQL_DATE_STRINGS=true
```

## Test Plan

- [x] TypeScript compiles without errors
- [x] Configuration options are correctly passed to mysql2 connection
- [ ] Manual testing with different timezone settings