### PR TITLE
Fix: Resolve symlinks in main module detection

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -36,9 +36,9 @@ import {
   poolPromise,
 } from "./src/db/index.js";
 
-import path from 'path';
 import express, { Request, Response } from "express";
 import { fileURLToPath } from 'url';
+import { realpathSync } from 'fs';
 
 
 log("info", `Starting MySQL MCP server v${version}...`);
@@ -402,7 +402,7 @@ const isMainModule = () => {
     // Convert the `import.meta.url` (e.g., 'file:///path/to/file.js') to a system-standard absolute path.
     const currentModulePath = fileURLToPath(import.meta.url);
     // Resolve `process.argv[1]` (which can be a relative path) to a standard absolute path.
-    const mainScriptPath = path.resolve(process.argv[1]);
+    const mainScriptPath = realpathSync(process.argv[1]);
     // Compare the two standardized absolute paths.
     return currentModulePath === mainScriptPath;
   }


### PR DESCRIPTION
# Fix: Resolve symlinks in main module detection

## Problem

When the script is executed via a symlink, `path.resolve()` doesn't resolve the symlink, causing `isMainModule()` to incorrectly return `false`.

## Solution

Replace `path.resolve()` with `fs.realpathSync()` to properly resolve symlinks to their actual file paths before comparison.

