### PR TITLE
feat: Add RDS/VPC SSH tunnel scripts with bastion support

### DIFF
--- a/scripts/start-tunnel-rds.sh
+++ b/scripts/start-tunnel-rds.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# start-tunnel-rds.sh
+# Creates an SSH tunnel from LOCAL_PORT -> RDS_ENDPOINT:RDS_PORT via a bastion host
+#
+# Usage:
+#   1. Set environment variables (or edit defaults below)
+#   2. Run: ./scripts/start-tunnel-rds.sh
+#
+# Environment Variables:
+#   LOCAL_PORT        - Local port to bind (default: 3307)
+#   BASTION_USER      - SSH user for bastion (default: ec2-user)
+#   BASTION_HOST      - Bastion/jump host IP or hostname (REQUIRED)
+#   BASTION_PORT      - SSH port on bastion (default: 22)
+#   RDS_ENDPOINT      - RDS instance endpoint (REQUIRED)
+#   RDS_PORT          - RDS port (default: 3306)
+#   SSH_KEY           - Path to SSH private key (default: ~/.ssh/id_rsa)
+
+set -euo pipefail
+
+# Configuration - Override via environment variables or edit defaults
+LOCAL_PORT="${LOCAL_PORT:-3307}"
+BASTION_USER="${BASTION_USER:-ec2-user}"
+BASTION_HOST="${BASTION_HOST:-}"  # e.g. 54.12.34.56 or bastion.example.com
+BASTION_PORT="${BASTION_PORT:-22}"
+RDS_ENDPOINT="${RDS_ENDPOINT:-}"  # e.g. mydb.abc123.us-east-1.rds.amazonaws.com
+RDS_PORT="${RDS_PORT:-3306}"
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/id_rsa}"
+
+# Validate required variables
+if [[ -z "$BASTION_HOST" ]]; then
+  echo "❌ Error: BASTION_HOST is required"
+  echo "   Set via: export BASTION_HOST=your-bastion-ip"
+  exit 1
+fi
+
+if [[ -z "$RDS_ENDPOINT" ]]; then
+  echo "❌ Error: RDS_ENDPOINT is required"
+  echo "   Set via: export RDS_ENDPOINT=your-db.region.rds.amazonaws.com"
+  exit 1
+fi
+
+if [[ ! -f "$SSH_KEY" ]]; then
+  echo "❌ Error: SSH key not found at $SSH_KEY"
+  echo "   Set via: export SSH_KEY=/path/to/your/key.pem"
+  exit 1
+fi
+
+BASTION_USER_HOST="${BASTION_USER}@${BASTION_HOST}"
+
+echo "🔗 Starting SSH tunnel to RDS"
+echo "   Local:   127.0.0.1:$LOCAL_PORT"
+echo "   Bastion: $BASTION_USER_HOST:$BASTION_PORT"
+echo "   RDS:     $RDS_ENDPOINT:$RDS_PORT"
+
+# Check if port is already in use (tunnel probably running)
+if lsof -Pi :$LOCAL_PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
+  echo "⚠️  Local port $LOCAL_PORT is already in use. Tunnel may already be running."
+  exit 0
+fi
+
+# Create the SSH tunnel
+ssh -i "$SSH_KEY" -f -N -L "$LOCAL_PORT:$RDS_ENDPOINT:$RDS_PORT" -p "$BASTION_PORT" "$BASTION_USER_HOST"
+
+sleep 1
+
+if lsof -Pi :$LOCAL_PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
+  echo "✅ SSH tunnel established!"
+  echo ""
+  echo "   Connection: 127.0.0.1:$LOCAL_PORT -> $RDS_ENDPOINT:$RDS_PORT"
+  echo ""
+  echo "   Set in your MCP config:"
+  echo "     MYSQL_HOST=127.0.0.1"
+  echo "     MYSQL_PORT=$LOCAL_PORT"
+else
+  echo "❌ Failed to create SSH tunnel"
+  exit 1
+fi

--- a/scripts/stop-tunnel-rds.sh
+++ b/scripts/stop-tunnel-rds.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# stop-tunnel-rds.sh
+# Stops the SSH tunnel created by start-tunnel-rds.sh
+#
+# Usage:
+#   ./scripts/stop-tunnel-rds.sh
+#   LOCAL_PORT=3308 ./scripts/stop-tunnel-rds.sh
+#
+# Environment Variables:
+#   LOCAL_PORT - Local port the tunnel is bound to (default: 3307)
+
+set -euo pipefail
+
+LOCAL_PORT="${LOCAL_PORT:-3307}"
+
+echo "🛑 Stopping SSH tunnel on local port $LOCAL_PORT..."
+
+PID=$(lsof -ti :$LOCAL_PORT 2>/dev/null || true)
+
+if [[ -n "$PID" ]]; then
+  echo "   Killing PID(s): $PID"
+  kill $PID 2>/dev/null || true
+  sleep 1
+  
+  if ! lsof -Pi :$LOCAL_PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
+    echo "✅ Tunnel stopped successfully"
+  else
+    echo "⚠️  Port $LOCAL_PORT still in use - may need manual cleanup"
+    echo "   Try: kill -9 \$(lsof -ti :$LOCAL_PORT)"
+  fi
+else
+  echo "ℹ️  No process found listening on port $LOCAL_PORT"
+fi

--- a/scripts/tunnel-config.example
+++ b/scripts/tunnel-config.example
@@ -1,0 +1,24 @@
+# SSH Tunnel Configuration for RDS/VPC Databases
+# Copy this file to tunnel-config.sh and fill in your values
+# Then source it before running the tunnel scripts:
+#   source scripts/tunnel-config.sh && ./scripts/start-tunnel-rds.sh
+
+# Local port to bind the tunnel (default: 3307)
+# Use different ports for multiple databases (3307, 3308, 3309, etc.)
+export LOCAL_PORT=3307
+
+# Bastion/Jump Host Configuration
+export BASTION_USER=ec2-user
+export BASTION_HOST=54.12.34.56          # Your bastion host IP or hostname
+export BASTION_PORT=22                    # SSH port (usually 22)
+
+# RDS Instance Configuration  
+export RDS_ENDPOINT=mydb.abc123xyz.us-east-1.rds.amazonaws.com
+export RDS_PORT=3306
+
+# SSH Key Path
+export SSH_KEY=$HOME/.ssh/my-aws-key.pem
+
+# After tunnel is running, use these in your MCP config:
+# MYSQL_HOST=127.0.0.1
+# MYSQL_PORT=3307


### PR DESCRIPTION
## Summary
Adds ready-to-use SSH tunnel scripts for connecting to RDS/MySQL databases in private VPCs through a bastion host.

## New Files
- `scripts/start-tunnel-rds.sh` - Creates SSH tunnel through bastion to RDS
- `scripts/stop-tunnel-rds.sh` - Cleanly stops the tunnel
- `scripts/tunnel-config.example` - Template configuration file

## Features
- All values configurable via environment variables (no hardcoded secrets)
- Validates required variables before attempting connection
- Graceful handling of already-running tunnels
- Clear output with connection details

## Usage
# Configure
export BASTION_HOST=54.12.34.56
export RDS_ENDPOINT=mydb.region.rds.amazonaws.com
export SSH_KEY=~/.ssh/my-key.pem

# Start tunnel
./scripts/start-tunnel-rds.sh

# Stop tunnel
./scripts/stop-tunnel-rds.sh