### PR TITLE
feat: add mTLS client certificate support (MYSQL_SSL_CERT, MYSQL_SSL_KEY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,8 @@ When `MYSQL_CONNECTION_STRING` is provided, it takes precedence over individual 
 - `MYSQL_MAX_QUERY_COMPLEXITY`: Maximum query complexity score (default: "1000")
 - `MYSQL_SSL`: Enable SSL/TLS encryption (default: "false")
 - `MYSQL_SSL_CA`: Path to SSL CA certificate file (PEM format). Only used when `MYSQL_SSL=true`. Required for connecting to MySQL instances with self-signed certificates or custom CAs.
+- `MYSQL_SSL_CERT`: Path to the client certificate file (PEM format) for mTLS. Only used when `MYSQL_SSL=true`. Enables mutual TLS (mTLS) authentication, where both the server and client present certificates. Required by some database configurations that enforce client certificate verification.
+- `MYSQL_SSL_KEY`: Path to the client private key file (PEM format) for mTLS. Only used when `MYSQL_SSL=true`. Must correspond to the certificate specified by `MYSQL_SSL_CERT`.
 - `ALLOW_INSERT_OPERATION`: Enable INSERT operations (default: "false")
 - `ALLOW_UPDATE_OPERATION`: Enable UPDATE operations (default: "false")
 - `ALLOW_DELETE_OPERATION`: Enable DELETE operations (default: "false")

--- a/index.ts
+++ b/index.ts
@@ -121,6 +121,8 @@ log(
       database: config.mysql.database || "MULTI_DB_MODE",
       ssl: process.env.MYSQL_SSL === "true" ? "enabled" : "disabled",
       sslCA: process.env.MYSQL_SSL_CA || "not set",
+      sslCert: process.env.MYSQL_SSL_CERT || "not set",
+      sslKey: process.env.MYSQL_SSL_KEY || "not set",
       multiDbMode: isMultiDbMode ? "enabled" : "disabled",
     },
     null,

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -5,4 +5,6 @@ This directory contains test fixtures for unit tests.
 ## Files
 
 - `valid-ca.pem` - A dummy CA certificate for testing SSL CA file reading
+- `valid-client-cert.pem` - A dummy client certificate for testing mTLS client certificate reading
+- `valid-client-key.pem` - A dummy client private key for testing mTLS client key reading
 - `empty.pem` - An empty file for testing error handling

--- a/tests/fixtures/valid-client-cert.pem
+++ b/tests/fixtures/valid-client-cert.pem
@@ -1,0 +1,6 @@
+-----BEGIN CERTIFICATE-----
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco.
+Test fixture only - not a real client certificate.
+-----END CERTIFICATE-----

--- a/tests/fixtures/valid-client-key.pem
+++ b/tests/fixtures/valid-client-key.pem
@@ -1,0 +1,6 @@
+-----BEGIN PRIVATE KEY-----
+Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco.
+Test fixture only - not a real private key.
+-----END PRIVATE KEY-----

--- a/tests/unit/ssl-mtls.test.ts
+++ b/tests/unit/ssl-mtls.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { readSSLFile } from '../../src/config/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('readSSLFile', () => {
+  const validCaPath = path.resolve(__dirname, '../fixtures/valid-ca.pem');
+  const validCertPath = path.resolve(__dirname, '../fixtures/valid-client-cert.pem');
+  const validKeyPath = path.resolve(__dirname, '../fixtures/valid-client-key.pem');
+  const emptyFilePath = path.resolve(__dirname, '../fixtures/empty.pem');
+  const nonExistentPath = '/path/to/nonexistent/file.pem';
+
+  describe('with CA certificate files', () => {
+    it('should read valid CA PEM file and return Buffer', () => {
+      const result = readSSLFile(validCaPath, 'CA certificate');
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+
+      const content = result.toString('utf8');
+      expect(content).toContain('-----BEGIN CERTIFICATE-----');
+      expect(content).toContain('-----END CERTIFICATE-----');
+    });
+  });
+
+  describe('with client certificate files (mTLS)', () => {
+    it('should read valid client certificate PEM file and return Buffer', () => {
+      const result = readSSLFile(validCertPath, 'client certificate');
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+
+      const content = result.toString('utf8');
+      expect(content).toContain('-----BEGIN CERTIFICATE-----');
+      expect(content).toContain('-----END CERTIFICATE-----');
+    });
+
+    it('should read valid client private key PEM file and return Buffer', () => {
+      const result = readSSLFile(validKeyPath, 'client private key');
+
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+
+      const content = result.toString('utf8');
+      expect(content).toContain('-----BEGIN PRIVATE KEY-----');
+      expect(content).toContain('-----END PRIVATE KEY-----');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw clear error for non-existent file', () => {
+      expect(() => {
+        readSSLFile(nonExistentPath, 'client certificate');
+      }).toThrow('SSL client certificate file not found');
+
+      expect(() => {
+        readSSLFile(nonExistentPath, 'client certificate');
+      }).toThrow(nonExistentPath);
+    });
+
+    it('should throw error for empty file', () => {
+      expect(() => {
+        readSSLFile(emptyFilePath, 'client certificate');
+      }).toThrow('SSL client certificate file is empty');
+
+      expect(() => {
+        readSSLFile(emptyFilePath, 'client certificate');
+      }).toThrow(emptyFilePath);
+    });
+
+    it('should include the label in error messages for different file types', () => {
+      expect(() => {
+        readSSLFile(nonExistentPath, 'client private key');
+      }).toThrow('SSL client private key file not found');
+
+      expect(() => {
+        readSSLFile(nonExistentPath, 'CA certificate');
+      }).toThrow('SSL CA certificate file not found');
+    });
+
+    it('should handle relative paths', () => {
+      const relativePath = path.relative(process.cwd(), validCertPath);
+
+      const result = readSSLFile(relativePath, 'client certificate');
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add support for mutual TLS (mTLS) authentication by introducing two new environment variables:

| Variable | Description |
|----------|-------------|
| `MYSQL_SSL_CERT` | Path to the client certificate file (PEM format) for mTLS |
| `MYSQL_SSL_KEY` | Path to the client private key file (PEM format) for mTLS |

These enable database setups that require client certificate verification, where both the server and client present certificates during the TLS handshake.

## Changes

### `src/config/index.ts`
- Added a generic `readSSLFile(filePath, label)` helper with proper validation (file-exists check, empty-file check, friendly error messages)
- Refactored existing `readCACertificate()` to delegate to `readSSLFile`, maintaining backward compatibility
- Added `MYSQL_SSL_CERT` and `MYSQL_SSL_KEY` to the SSL config block (inside the `MYSQL_SSL=true` conditional), using `readSSLFile` for consistent error handling

### `README.md`
- Documented `MYSQL_SSL_CERT` and `MYSQL_SSL_KEY` in the Security Configuration section alongside existing SSL variables

### Tests
- Added `tests/unit/ssl-mtls.test.ts` with 7 tests covering:
  - Reading client certificate and key files
  - Error handling for missing files, empty files
  - Label inclusion in error messages for different file types
  - Relative path support
- Added test fixtures: `valid-client-cert.pem`, `valid-client-key.pem`
- Updated `tests/fixtures/README.md`
- All existing `readCACertificate` tests continue to pass unchanged

## Usage

```bash
MYSQL_SSL=true
MYSQL_SSL_CA=/path/to/ca.pem
MYSQL_SSL_CERT=/path/to/client-cert.pem
MYSQL_SSL_KEY=/path/to/client-key.pem
```

## No dependency changes

This feature uses only the `fs` built-in module, which was already imported. No new dependencies are added.