### PR TITLE
fix: use AST parser for schema extraction to prevent permission bypass

### DIFF
--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -5,7 +5,10 @@ import SqlParser, { AST } from "node-sql-parser";
 const { Parser } = SqlParser;
 const parser = new Parser();
 
-// Extract schema from SQL query
+// Extract schema from SQL query using the AST parser for accuracy.
+// Previous regex-based extraction could be bypassed with SQL comments
+// (e.g. USE/**/schema_name) which allowed schema permission checks to
+// fall through to the global default.
 function extractSchemaFromQuery(sql: string): string | null {
   // Default schema from environment
   const defaultSchema = process.env.MYSQL_DB || null;
@@ -15,18 +18,31 @@ function extractSchemaFromQuery(sql: string): string | null {
     return defaultSchema;
   }
 
-  // Try to extract schema from query
+  // Use the AST parser to reliably extract schema information
+  try {
+    const astOrArray: AST | AST[] = parser.astify(sql, { database: "mysql" });
+    const statements = Array.isArray(astOrArray) ? astOrArray : [astOrArray];
 
-  // Case 1: USE database statement
-  const useMatch = sql.match(/USE\s+`?([a-zA-Z0-9_]+)`?/i);
-  if (useMatch && useMatch[1]) {
-    return useMatch[1];
-  }
+    for (const stmt of statements) {
+      // Case 1: USE database statement
+      if (stmt.type === "use" && (stmt as any).db) {
+        return (stmt as any).db;
+      }
 
-  // Case 2: database.table notation
-  const dbTableMatch = sql.match(/`?([a-zA-Z0-9_]+)`?\.`?[a-zA-Z0-9_]+`?/i);
-  if (dbTableMatch && dbTableMatch[1]) {
-    return dbTableMatch[1];
+      // Case 2: database.table notation in FROM/INTO clauses
+      const tables = (stmt as any).table || (stmt as any).from;
+      if (Array.isArray(tables)) {
+        for (const t of tables) {
+          if (t.db) {
+            return t.db;
+          }
+        }
+      } else if (tables && typeof tables === "object" && tables.db) {
+        return tables.db;
+      }
+    }
+  } catch (err: any) {
+    log("error", "Failed to parse SQL for schema extraction:", err.message);
   }
 
   // Return default if we couldn't find a schema in the query


### PR DESCRIPTION
## Summary

Fixes #118

Replaces the regex-based schema extraction in `extractSchemaFromQuery()` with the already-imported `node-sql-parser` for reliable parsing.

## Problem

The regex `USE\s+` requires literal whitespace after `USE`. MySQL accepts SQL comments as separators (e.g., `USE/**/production`), but the regex does not match this, causing schema-specific permissions to fall through to the global default.

## Changes

| File | Change |
|------|--------|
| `src/db/utils.ts` | Replace regex with `parser.astify()` to extract schema from USE statements and qualified table names via AST |

## Verification

- `npx tsc` compiles with zero errors
- Existing unit tests pass (4 pre-existing failures unrelated to this change — same results on `main`)
- The `node-sql-parser` dependency is already used by `getQueryTypes()` in the same file, so no new dependencies

## Test Plan

- [ ] `npx tsc` passes
- [ ] `npx vitest run tests/unit/query.test.ts` — same results as main branch
- [ ] Manual: verify `USE production; SELECT 1` correctly extracts schema `production`
- [ ] Manual: verify `USE/**/production; SELECT 1` is now correctly parsed (previously bypassed regex)
---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*