### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ A Model Context Protocol server that provides access to MySQL databases through 
 - MySQL user with appropriate permissions for the operations you need
 - For write operations: MySQL user with INSERT, UPDATE, and/or DELETE privileges
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/benborla29-mcp-server-mysql).
+
 ## Installation
 
 ### Using Smithery


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/benborla29-mcp-server-mysql).