### PR TITLE
fix: restrict information_schema queries to configured database in si…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -190,6 +190,8 @@ export default function createMcpServer({
       log("info", `Connection info: ${connectionInfo}`);
 
       // Query to get all tables
+      // In single-DB mode, restrict queries to the configured database to avoid
+      // performance issues with large numbers of tables across multiple schemas.
       const tablesQuery = `
       SELECT
         table_name as name,
@@ -204,6 +206,7 @@ export default function createMcpServer({
         information_schema.tables
       WHERE
         table_schema NOT IN ('information_schema', 'mysql', 'performance_schema', 'sys')
+        ${!isMultiDbMode && config.mysql.database ? `AND table_schema = '${config.mysql.database}'` : ''}
       ORDER BY
         table_schema, table_name
     `;
@@ -258,9 +261,12 @@ export default function createMcpServer({
         "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = ?";
       let queryParams = [tableName as string];
 
-      if (dbName) {
+      // In single-DB mode, if no dbName is provided in URI, use the configured database
+      const schemaName = dbName || (!isMultiDbMode ? config.mysql.database : null);
+
+      if (schemaName) {
         columnsQuery += " AND table_schema = ?";
-        queryParams.push(dbName);
+        queryParams.push(schemaName);
       }
 
       const results = (await executeQuery(


### PR DESCRIPTION
…ngle-DB mode

In single-DB mode (when MYSQL_DB is set), the ListResourcesRequest handler was querying information_schema.tables across all non-system schemas, ignoring the MYSQL_DB configuration. This caused severe performance issues in environments with many schemas and thousands of tables, as MySQL would scan all metadata regardless of the configured database.

Changes:
- ListResourcesRequest: Add WHERE clause filter for table_schema when MYSQL_DB is set and not in multi-DB mode
- ReadResourceRequest: Use configured database as default schema when no dbName is specified in the URI

This fix ensures that when MYSQL_DB is configured, only tables from that specific database are queried, preventing CPU spikes from scanning thousands of tables across multiple schemas.