### PR TITLE
fix: add MYSQL_BIG_NUMBER_STRINGS env var to prevent BIGINT precision loss

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -171,6 +171,14 @@ export const mcpConfig = {
           dateStrings: true,
         }
       : {}),
+    // Return BIGINT/DECIMAL values as strings to prevent precision loss
+    // This is essential for tables using snowflake IDs (19-digit IDs) which exceed Number.MAX_SAFE_INTEGER (2^53-1)
+    ...(process.env.MYSQL_BIG_NUMBER_STRINGS === "true"
+      ? {
+          supportBigNumbers: true,
+          bigNumberStrings: true,
+        }
+      : {}),
   },
   paths: {
     schema: "schema",


### PR DESCRIPTION
## Problem

BIGINT column values that exceed JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 - 1) are truncated when returned by the MCP server. This affects any table using **snowflake IDs** (19-digit IDs), where IDs like `2047948614742839297` get truncated to `2047948614742839300`.

Related issue: #131

## Fix

Add `MYSQL_BIG_NUMBER_STRINGS` environment variable support in `src/config/index.ts`, which enables `supportBigNumbers` and `bigNumberStrings` in the mysql2 pool config when set to `true`.

This makes BIGINT/DECIMAL values return as strings instead of JavaScript Numbers, preserving full precision.

## Usage

Add to your MCP config:

```json
{
  "env": {
    "MYSQL_BIG_NUMBER_STRINGS": "true"
  }
}
```

## Side Effects

When enabled, all BIGINT and DECIMAL columns will be returned as strings (e.g. `"2047948614742839297"` instead of `2047948614742839300`). This is generally acceptable for MCP query scenarios where results are read-only.

Disabled by default to maintain backward compatibility.

## Testing

Verified with a table using snowflake IDs:
- Before: `id: 2047948614742839300` (precision lost)
- After: `id: "2047948614742839297"` (precision preserved)
