### PR TITLE
fix(remote-mcp): create per-request Server in POST /mcp to fix parallel-request hang

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -467,7 +467,7 @@ if (isMainModule()) {
             return;
           }
           try {
-            const server = mcpServer;
+            const server = createMcpServer({ config: { debug: false } });
             const transport: StreamableHTTPServerTransport =
               new StreamableHTTPServerTransport({
                 sessionIdGenerator: undefined,

--- a/tests/integration/remote-mcp-parallel.test.ts
+++ b/tests/integration/remote-mcp-parallel.test.ts
@@ -1,0 +1,116 @@
+import { spawn, ChildProcess } from "child_process";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as dotenv from "dotenv";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+// Set test directory path
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Load test environment variables
+dotenv.config({ path: path.resolve(__dirname, "../../.env.test") });
+
+// Non-default port to avoid colliding with anything else the developer may run
+const PORT = "39737";
+const SECRET = "test-secret-key";
+const SERVER_URL = `http://127.0.0.1:${PORT}/mcp`;
+const SERVER_START_TIMEOUT_MS = 15000;
+
+describe("Remote MCP HTTP mode — parallel /mcp requests", () => {
+  let serverProcess: ChildProcess;
+
+  beforeAll(async () => {
+    const serverPath = path.resolve(__dirname, "../../dist/index.js");
+    serverProcess = spawn("node", [serverPath], {
+      env: {
+        ...process.env,
+        IS_REMOTE_MCP: "true",
+        REMOTE_SECRET_KEY: SECRET,
+        PORT,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    // Wait for the express server to print its "listening" line
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("Server did not start in time")),
+        SERVER_START_TIMEOUT_MS,
+      );
+
+      const onData = (chunk: Buffer) => {
+        if (chunk.toString().includes("listening on port")) {
+          clearTimeout(timer);
+          resolve();
+        }
+      };
+
+      serverProcess.stdout?.on("data", onData);
+      serverProcess.stderr?.on("data", onData);
+
+      serverProcess.once("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+
+      serverProcess.once("exit", (code) => {
+        clearTimeout(timer);
+        reject(new Error(`Server exited early with code ${code}`));
+      });
+    });
+  }, 30000);
+
+  afterAll(() => {
+    if (serverProcess && !serverProcess.killed) {
+      serverProcess.kill("SIGTERM");
+    }
+  });
+
+  async function callMcp(
+    reqId: number,
+    sql: string,
+    timeoutMs: number,
+  ): Promise<{ status: number; text: string }> {
+    const res = await fetch(SERVER_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${SECRET}`,
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: reqId,
+        method: "tools/call",
+        params: { name: "mysql_query", arguments: { sql } },
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return { status: res.status, text: await res.text() };
+  }
+
+  // Regression test for the bug where two parallel POST /mcp requests share
+  // the module-level Server instance: the first response's res.on("close")
+  // handler calls server.close() on the shared Server, severing every other
+  // in-flight transport. Without the per-request createMcpServer() fix, one
+  // of the two requests below hangs forever and the AbortSignal trips the
+  // test's per-request timeout.
+  it("returns correct results to two concurrent tools/call requests", async () => {
+    const [r1, r2] = await Promise.all([
+      callMcp(1, "SELECT SLEEP(1) AS slept, 1 AS req_id", 8000),
+      callMcp(2, "SELECT SLEEP(1) AS slept, 2 AS req_id", 8000),
+    ]);
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+
+    // SSE response embeds the tool result as a JSON-encoded string, so the
+    // inner field appears as \"req_id\": N in the raw response bytes.
+    expect(r1.text).toContain('\\"req_id\\": 1');
+    expect(r2.text).toContain('\\"req_id\\": 2');
+
+    expect(r1.text).not.toContain('"isError":true');
+    expect(r2.text).not.toContain('"isError":true');
+  }, 20000);
+});


### PR DESCRIPTION
## Summary
Fixes a hang in `IS_REMOTE_MCP=true` HTTP mode where two parallel `POST /mcp` requests cause one of them to never return. The first request to finish executes its `res.on(\"close\", …)` handler, which calls `server.close()` on a `Server` instance that is shared with every other in-flight request. The other request's transport gets severed and its `tools/call` promise never resolves.

Fixes #135.

## Why this matters in practice
AI coding agents (Claude Code, Cursor) batch independent tool calls in a single turn. The first time an agent issues two parallel `mysql_query` calls against an `IS_REMOTE_MCP=true` server, this bug hangs one of them forever — Node process stays alive, so external watchdogs don't catch it, and the agent loop sits blocked waiting for a result that will never come.

## Root cause
`app.post(\"/mcp\", …)` correctly creates a **per-request transport** but binds it to the **shared, module-level `mcpServer`**. When the first request's `res` closes, the handler calls `server.close()` on that shared server, breaking every other in-flight request bound to it.

The comment immediately above the buggy block already documents the intended behaviour:

> *In stateless mode, create a new instance of transport and server for each request to ensure complete isolation. A single instance would cause request ID collisions when multiple clients connect concurrently.*

This PR makes the code match its own comment.

## Change

\`\`\`diff
-          const server = mcpServer;
+          const server = createMcpServer({ config: { debug: false } });
\`\`\`

That's the entire production diff. `createMcpServer` is already the default export of this file and is already called on startup. The MySQL connection pool is module-scoped (`poolPromise` in `src/db/index.ts`), so creating a new `Server` per request does **not** open additional DB connections — the pool is reused.

## Why this is safe
- Stdio mode (`IS_REMOTE_MCP` unset) is untouched — it still calls `mcpServer.connect(transport)` at startup.
- HTTP mode is the only path that registers `res.on(\"close\", … server.close())`, so making the server per-request is what `res.on(\"close\")` already expected.
- `getPool()` / `poolPromise` are unchanged; DB connection count is unaffected.

## Verification
Reproduced and verified locally against MySQL 8.0.46 in Docker, using a Node script that fires N parallel POSTs to `http://127.0.0.1:3000/mcp` with `mysql_query(\"SELECT SLEEP(N)\")` and a per-request client timeout.

**Before this patch, on `main` @ d17bd4e:**

\`\`\`
5 batches × 2 parallel SELECT SLEEP(2), per-request timeout 8s:
batch=0 req=1 ok=false ms=8003  | TimeoutError (hung)
batch=0 req=2 ok=true  ms=2015  | \"req_id\": 2
batch=1 req=3 ok=false ms=8000  | TimeoutError (hung)
batch=1 req=4 ok=true  ms=2012  | \"req_id\": 4
... pattern repeats ...
SUMMARY: 5/10 ok | errs=5
\`\`\`

Exactly one request per batch hangs, every batch, every time. Node process stays alive throughout.

**With this patch:**

\`\`\`
Same test, 5 batches × 2 parallel SELECT SLEEP(2):
SUMMARY: 10/10 ok | p50=2013ms p99=2042ms | errs=0

Stress, 50 batches × parallelism=10 SELECT SLEEP(1):
SUMMARY: 500/500 ok | p50=1011ms p99=1027ms | errs=0
\`\`\`

Latency overhead is ~10–27 ms over the SQL's own SLEEP, i.e. negligible.

## Test plan
- [x] \`pnpm install && pnpm build\` — TypeScript compiles
- [x] \`pnpm test\` — same 10 pre-existing failures as `main` (in `tests/integration/schema-permissions/` and `tests/integration/multi-db/`, unrelated to this fix and reproducible on unmodified `main`); 1 new test added and passing
- [x] New regression test: \`tests/integration/remote-mcp-parallel.test.ts\`
  - Spawns \`dist/index.js\` with \`IS_REMOTE_MCP=true\`, fires two concurrent \`tools/call\` requests for \`SELECT SLEEP(1)\`, asserts both return the correct \`req_id\`.
  - **Fails on unmodified `main`** with a \`TimeoutError\` at ~8 s (the abort timeout): one of the two requests hangs indefinitely.
  - **Passes with this fix** in ~1.3 s.
- [x] Manual stress: 50 batches × parallelism=10 with \`SELECT SLEEP(1)\` — 500/500 succeed, p99=1027 ms.

## Out of scope (intentional)
The outer \`const mcpServer = createMcpServer({ config: { debug: false } })\` at startup becomes unused on the HTTP path after this fix. Left alone to keep the diff minimal and the stdio path unchanged; happy to remove it in a follow-up if preferred.

Made with [Cursor](https://cursor.com)