### PR TITLE
fix: add repository, bugs, and homepage metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,5 +83,13 @@
     "mcp-patch",
     "mcp-options",
     "mcp-head"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/benborla/mcp-server-mysql.git"
+  },
+  "bugs": {
+    "url": "https://github.com/benborla/mcp-server-mysql/issues"
+  },
+  "homepage": "https://github.com/benborla/mcp-server-mysql"
 }


### PR DESCRIPTION
The published npm package `@benborla29/mcp-server-mysql` omits standard `repository`, `bugs`, and `homepage` fields. Adding these helps users and tooling navigate from npm back to the source.

### Changes
- Added `repository` field (type + url)
- Added `bugs` field (issue tracker URL)
- Added `homepage` field (GitHub repo URL)

### Validation
- `npm pack` produces valid output
- `npm view` shows the new fields
- Single-line additions, zero behavior change