### PR TITLE
Add support for EXPLAIN ANALYZE

### DIFF
--- a/src/db/utils.ts
+++ b/src/db/utils.ts
@@ -33,11 +33,32 @@ function extractSchemaFromQuery(sql: string): string | null {
   return defaultSchema;
 }
 
+/**
+ * MySQL EXPLAIN accepts optional modifiers between EXPLAIN and the statement:
+ *   ANALYZE, EXTENDED, PARTITIONS, FORMAT=<word>
+ *
+ * node-sql-parser only understands bare `EXPLAIN <statement>` — any modifier
+ * after EXPLAIN causes a parse error. Strip them before handing to the parser
+ * so that e.g. `EXPLAIN ANALYZE SELECT …` is treated the same as
+ * `EXPLAIN SELECT …` (operation type `"explain"`, routed as read-only).
+ *
+ * Multiple modifiers may appear together, e.g. `EXPLAIN ANALYZE FORMAT=JSON`.
+ */
+const EXPLAIN_MODIFIER_RE =
+  /^(\s*EXPLAIN\s+)((?:ANALYZE\s+|EXTENDED\s+|PARTITIONS\s+|FORMAT\s*=\s*\w+\s+)+)/i;
+
+function stripExplainModifiers(sql: string): string {
+  return sql.replace(EXPLAIN_MODIFIER_RE, "$1");
+}
+
 async function getQueryTypes(query: string): Promise<string[]> {
   try {
     log("info", "Parsing SQL query: ", query);
+    // Strip unsupported EXPLAIN modifiers (ANALYZE, FORMAT=…, EXTENDED, PARTITIONS)
+    // before parsing so node-sql-parser can handle them.
+    const normalised = stripExplainModifiers(query);
     // Parse into AST or array of ASTs - only specify the database type
-    const astOrArray: AST | AST[] = parser.astify(query, { database: "mysql" });
+    const astOrArray: AST | AST[] = parser.astify(normalised, { database: "mysql" });
     const statements = Array.isArray(astOrArray) ? astOrArray : [astOrArray];
 
     // Map each statement to its lowercased type (e.g., 'select', 'update', 'insert', 'delete', etc.)

--- a/tests/unit/get-query-types.test.ts
+++ b/tests/unit/get-query-types.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { getQueryTypes } from "../../src/db/utils.js";
+
+describe("getQueryTypes", () => {
+  describe("standard DML statements", () => {
+    it("classifies SELECT as select", async () => {
+      expect(await getQueryTypes("SELECT id FROM users")).toEqual(["select"]);
+    });
+
+    it("classifies INSERT as insert", async () => {
+      expect(
+        await getQueryTypes("INSERT INTO users (name) VALUES ('alice')"),
+      ).toEqual(["insert"]);
+    });
+
+    it("classifies UPDATE as update", async () => {
+      expect(
+        await getQueryTypes("UPDATE users SET name = 'bob' WHERE id = 1"),
+      ).toEqual(["update"]);
+    });
+
+    it("classifies DELETE as delete", async () => {
+      expect(await getQueryTypes("DELETE FROM users WHERE id = 1")).toEqual([
+        "delete",
+      ]);
+    });
+  });
+
+  describe("EXPLAIN without modifiers", () => {
+    it("classifies EXPLAIN SELECT as explain", async () => {
+      expect(
+        await getQueryTypes("EXPLAIN SELECT id FROM users"),
+      ).toEqual(["explain"]);
+    });
+  });
+
+  describe("EXPLAIN ANALYZE and other modifiers (MySQL 8.0+)", () => {
+    it("classifies EXPLAIN ANALYZE SELECT as explain (not a parse error)", async () => {
+      expect(
+        await getQueryTypes("EXPLAIN ANALYZE SELECT id FROM users"),
+      ).toEqual(["explain"]);
+    });
+
+    it("classifies EXPLAIN ANALYZE SELECT with lowercase as explain", async () => {
+      expect(
+        await getQueryTypes("explain analyze select id from users"),
+      ).toEqual(["explain"]);
+    });
+
+    it("classifies EXPLAIN ANALYZE SELECT with a WHERE clause as explain", async () => {
+      expect(
+        await getQueryTypes(
+          "EXPLAIN ANALYZE SELECT id, name FROM users WHERE id > 10",
+        ),
+      ).toEqual(["explain"]);
+    });
+
+    it("classifies EXPLAIN FORMAT=JSON SELECT as explain", async () => {
+      expect(
+        await getQueryTypes("EXPLAIN FORMAT=JSON SELECT id FROM users"),
+      ).toEqual(["explain"]);
+    });
+
+    it("classifies EXPLAIN FORMAT = TREE SELECT as explain (spaces around =)", async () => {
+      expect(
+        await getQueryTypes("EXPLAIN FORMAT = TREE SELECT id FROM users"),
+      ).toEqual(["explain"]);
+    });
+
+    it("classifies EXPLAIN EXTENDED SELECT as explain", async () => {
+      expect(
+        await getQueryTypes("EXPLAIN EXTENDED SELECT id FROM users"),
+      ).toEqual(["explain"]);
+    });
+
+    it("classifies EXPLAIN PARTITIONS SELECT as explain", async () => {
+      expect(
+        await getQueryTypes("EXPLAIN PARTITIONS SELECT id FROM users"),
+      ).toEqual(["explain"]);
+    });
+
+    it("classifies EXPLAIN ANALYZE FORMAT=JSON SELECT (multiple modifiers) as explain", async () => {
+      expect(
+        await getQueryTypes(
+          "EXPLAIN ANALYZE FORMAT=JSON SELECT id FROM users",
+        ),
+      ).toEqual(["explain"]);
+    });
+  });
+
+  describe("EXPLAIN is not a write operation", () => {
+    it("EXPLAIN ANALYZE SELECT does not appear in write-operation type lists", async () => {
+      const types = await getQueryTypes(
+        "EXPLAIN ANALYZE SELECT id FROM users",
+      );
+      const writeTypes = [
+        "insert",
+        "update",
+        "delete",
+        "create",
+        "alter",
+        "drop",
+        "truncate",
+      ];
+      expect(types.some((t) => writeTypes.includes(t))).toBe(false);
+    });
+  });
+
+  describe("throws on genuinely invalid SQL", () => {
+    it("throws Parsing failed for non-SQL input", async () => {
+      await expect(
+        getQueryTypes("THIS IS NOT VALID SQL ;;;"),
+      ).rejects.toThrow("Parsing failed");
+    });
+  });
+});


### PR DESCRIPTION
## Allow `EXPLAIN ANALYZE` (and other EXPLAIN modifiers) in the SQL parser

### Problem


`EXPLAIN SELECT` already worked and produced operation type `"explain"`, which
is correctly routed as read-only. The issue was purely the modifier keywords
the parser did not recognise.

### Solution

Added `stripExplainModifiers()` in `src/db/utils.ts` — a small regex
pre-processing step applied inside `getQueryTypes` before the query reaches
the parser. It strips unsupported modifiers, converting e.g.:

| Input | Normalised for parser |
|---|---|
| `EXPLAIN ANALYZE SELECT …` | `EXPLAIN SELECT …` |
| `EXPLAIN FORMAT=JSON SELECT …` | `EXPLAIN SELECT …` |
| `EXPLAIN EXTENDED SELECT …` | `EXPLAIN SELECT …` |
| `EXPLAIN ANALYZE FORMAT=JSON SELECT …` | `EXPLAIN SELECT …` |

The normalisation is applied **only** in `getQueryTypes` (where a parse failure
throws). The PII helpers (`containsSelectStar`, `findPIIColumnReferences`) are
intentionally left unchanged — their existing fail-open behaviour on parse
errors is correct for EXPLAIN queries, since EXPLAIN returns a query plan, not
actual row data.

The resulting operation type `"explain"` is not in any write-operation set
(`insert`, `update`, `delete`, `create`, `alter`, `drop`, `truncate`), so
`EXPLAIN ANALYZE` queries are correctly routed through the read-only execution
path.

### Files changed

- **`src/db/utils.ts`** — added `EXPLAIN_MODIFIER_RE` regex constant,
  `stripExplainModifiers()` helper, and one-line call in `getQueryTypes`.

### Tests added

- **`tests/unit/get-query-types.test.ts`** (15 tests, new file)
  - Standard DML baseline (`SELECT`, `INSERT`, `UPDATE`, `DELETE`)
  - `EXPLAIN SELECT` baseline (no regression)
  - `EXPLAIN ANALYZE SELECT` — upper, lower, with `WHERE`
  - `EXPLAIN FORMAT=JSON`, `FORMAT = TREE` (spaces around `=`)
  - `EXPLAIN EXTENDED`, `EXPLAIN PARTITIONS`
  - `EXPLAIN ANALYZE FORMAT=JSON` (multiple modifiers combined)
  - Asserts `explain` type never appears in the write-operation set
  - Asserts genuinely invalid SQL still throws `Parsing failed`
  
  
## E2e test w/ MCP server running these changes
  
Prompt>
```
Is the otr database MCP still working? if so can you run a explain analyze select * from USERS; SQL statement
```

Output
<img width="778" height="438" alt="Screenshot 2026-06-23 at 12 44 33 PM" src="https://github.com/user-attachments/assets/73cf914f-8e40-4780-adfd-edbd16ae4bce" />
